### PR TITLE
Add aftman support

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,3 @@
+[tools]
+rojo = "rojo-rbx/rojo@7.4.1"
+lune = "lune-org/lune@0.8.5"


### PR DESCRIPTION
Adds an `aftman.toml`, so that users using Aftman can build AutoImport